### PR TITLE
Use ml_collections and stop passing around dtype.

### DIFF
--- a/examples/retinanet/configs/default.py
+++ b/examples/retinanet/configs/default.py
@@ -1,30 +1,9 @@
-from jax.numpy import float32
-
-
-class ConfigDict(dict):
-  """Dictionary with dot access to values."""
-
-  def __getattr__(self, attr):
-    return self[attr]
-
-  def __setattr__(self, key, value):
-    self[key] = value
-
-  def __setitem__(self, key, value):
-    super().__setitem__(key, value)
-    self.__dict__.update({key: value})
-
-  def __delattr__(self, item):
-    self.__delitem__(item)
-
-  def __delitem__(self, key):
-    super().__delitem__(key)
-    del self.__dict__[key]
+import ml_collections
 
 
 def get_config():
   """Get the default hyperparameter configuration."""
-  config = ConfigDict()
+  config = ml_collections.ConfigDict()
 
   config.learning_rate = 0.01
   config.per_device_batch_size = 2
@@ -33,18 +12,25 @@ def get_config():
   config.half_precision = False
   config.try_restore = False
   config.distributed_training = True
-  config.dtype = float32
 
   # The number of layers in the RetinaNet backbone.
   config.depth = 50
 
   config.sync_steps = 100
   config.checkpoint_period = 1_500
-  config.seed = 42
 
   # Evaluation parameters
   config.eval_annotations_path = "/home/dgraur/data/files/coco_annotations/instances_val2014.json"
   config.eval_remove_background = True
   config.eval_threshold = 0.05
 
+  config.seed = 42
+
+  config.trial = 0  # Dummy for repeated runs.
   return config
+
+
+def get_hyper(h):
+  return h.product([
+      h.sweep("trial", range(1)),
+  ], name="config")

--- a/examples/retinanet/input_pipeline.py
+++ b/examples/retinanet/input_pipeline.py
@@ -1,6 +1,7 @@
 from typing import Iterable, Tuple
 
 from clu import deterministic_data
+import ml_collections
 from flax import jax_utils
 import jax
 import jax.numpy as jnp
@@ -604,7 +605,7 @@ def eval_preprocess_fn(features):
   return fn(features)
 
 
-def create_datasets(config, rng) -> Tuple[tfds.core.DatasetInfo, tf.data.Dataset, tf.data.Dataset]:
+def create_datasets(config: ml_collections.ConfigDict, rng) -> Tuple[tfds.core.DatasetInfo, tf.data.Dataset, tf.data.Dataset]:
   """Create datasets for training and evaluation.
 
   Args:


### PR DESCRIPTION
1) ConfigDict is now released: pip install ml-collections
2) Configs should not import anything but ml_collections.ConfigDict.
This is cleaner and required for compatibility with some internal tools.
3) The reason to have dtype everywhere is to support lower precision
values for additional speed gains. This should not be part of this
example.